### PR TITLE
Fix sub-user login and documentation update

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,27 +10,29 @@ An [octoDNS](https://github.com/octodns/octodns/) provider that targets ClouDNS.
 pip install octodns-cloudns
 ```
 
-#### requirements.txt/setup.py
-
-Pinning specific versions or SHAs is recommended to avoid unplanned upgrades.
-
-##### Versions
-
-```
-# Start with the latest versions and don't just copy what's here
-octodns==0.9.14
-octodns-cloudns==0.0.1
-```
-
 ### Configuration
+
+For more safety, we recommend you to use an API sub-user with limited permissions.
+You can create it from [your ClouDNS account](https://www.cloudns.net/api-settings/)
+and store your credentials in environment variables:
+
+```bash
+export CLOUDNS_API_AUTH_ID=XXXXX
+export CLOUDNS_API_AUTH_PASSWORD=XXXXX
+```
+
+Then add your ClouDNS account to your octoDNS configuration file:
 
 ```yaml
 providers:
   cloudns_account:
-    class: octodns.provider.cloudns.ClouDNSProvider
-    auth_id: <api_auth_id>
-    auth_password: <api_auth_password>
+    class: octodns_cloudns.ClouDNSProvider
+    auth_id: env/CLOUDNS_API_AUTH_ID
+    auth_password: env/CLOUDNS_API_AUTH_PASSWORD
+    # "sub_auth" must be enabled if *only* you log in using a sub-user.
+    sub_auth: true
 ```
+
 
 ### Support Information
 

--- a/octodns_cloudns/__init__.py
+++ b/octodns_cloudns/__init__.py
@@ -242,11 +242,11 @@ class ClouDNSProvider(BaseProvider):
         ]
     )
 
-    def __init__(self, id, auth_id, auth_password, *args, **kwargs):
+    def __init__(self, id, auth_id, auth_password, sub_auth=False, *args, **kwargs):
         self.log = getLogger(f"ClouDNSProvider[{id}]")
-        self.log.debug("__init__: id=%s, auth_id=***", id)
+        self.log.debug("__init__: id=%s, auth_id=***, auth_password=***, sub_auth=%s", id, sub_auth)
         super().__init__(id, *args, **kwargs)
-        self._client = ClouDNSClient(auth_id, auth_password, id)
+        self._client = ClouDNSClient(auth_id, auth_password, id, sub_auth)
 
         self._zone_records = {}
 


### PR DESCRIPTION
This PR fixes a few issues:

- sub-user auth doesn't work (`TypeError: BaseProvider.__init__() got an unexpected keyword argument 'sub_auth'`)
- `sub_auth` configuration option isn't documented anywhere
- Documentation mention a wrong value for the `class` attribute: `octodns_cloudns.ClouDNSProvider` should be used instead of `octodns.provider.cloudns.ClouDNSProvider`

Regarding the last point, you should probably update the [official wiki](https://www.cloudns.net/wiki/article/509) who recommends to install `octodns-cloudns` and to manually copy its `__init__.py` file into `octodns` directory, who will be erased at each update...

I've also removed the advise to stick to a specific version as octoDNS API is stable and should not break in futures upgrades, while sticking to a specific version is generally bad for security.
Configuration instructions has been updated to store credentials in environment variables.