### PR TITLE
Bump version string to 0.0.9

### DIFF
--- a/octodns_cloudns/__init__.py
+++ b/octodns_cloudns/__init__.py
@@ -8,7 +8,7 @@ from octodns.record import Record
 logging.basicConfig(level=logging.DEBUG)
 logger = logging.getLogger(__name__)
 
-__version__ = __VERSION__ = '0.0.8'
+__version__ = __VERSION__ = '0.0.9'
 
 class ClouDNSClientException(ProviderException):
     pass


### PR DESCRIPTION
The ci builder checks for the version string in `__init__.py`. This version was not bumped when the latest round of PRs were merged and no new package was cut.